### PR TITLE
chore: upgrade sendgrid to v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php-amqplib/php-amqplib": "^3.0",
     "doctrine/dbal": "^4.0",
     "ramsey/uuid": "^4.1",
-    "sendgrid/sendgrid": "^7.9",
+    "sendgrid/sendgrid": "^8.0",
     "ext-curl": "*",
     "ext-json": "*"
   },


### PR DESCRIPTION
Related task(s): https://app.notion.com/p/uhin/Upgrade-to-Laravel-13-Low-Priority-Due-May-28-2026-336664781d1a806c87aef60f81d3736e

- Upgrades `sendgrid` library to `^8.0` for compatibility changes with other libraries.

Tested locally.